### PR TITLE
Fix missing layout file handling

### DIFF
--- a/Assets/TutorialInfo/Scripts/Editor/ReadmeEditor.cs
+++ b/Assets/TutorialInfo/Scripts/Editor/ReadmeEditor.cs
@@ -68,10 +68,17 @@ public class ReadmeEditor : Editor
 
     static void LoadLayout()
     {
+        var layoutPath = Path.Combine(Application.dataPath, "TutorialInfo/Layout.wlt");
+        if (!File.Exists(layoutPath))
+        {
+            Debug.LogWarning($"Layout file not found at {layoutPath}. Skipping window layout load.");
+            return;
+        }
+
         var assembly = typeof(EditorApplication).Assembly;
         var windowLayoutType = assembly.GetType("UnityEditor.WindowLayout", true);
         var method = windowLayoutType.GetMethod("LoadWindowLayout", BindingFlags.Public | BindingFlags.Static);
-        method.Invoke(null, new object[] { Path.Combine(Application.dataPath, "TutorialInfo/Layout.wlt"), false });
+        method.Invoke(null, new object[] { layoutPath, false });
     }
 
     static Readme SelectReadme()


### PR DESCRIPTION
## Summary
- guard `LoadLayout()` in `ReadmeEditor` so loading the layout does not crash if `Layout.wlt` is missing

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_684dafad50688320ad0535bc3da4c8ef