### PR TITLE
Add player movement script

### DIFF
--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: ec21169831104b559d166450e50d38d0
+folderAsset: yes
+timeCreated: 1718731126
+licenseType: Free
+DefaultImporter:
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Player.meta
+++ b/Assets/Scripts/Player.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 9356543ffe1d41f387ea79ced9a8338f
+folderAsset: yes
+timeCreated: 1718731126
+licenseType: Free
+DefaultImporter:
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Player/PlayerMovement.cs
+++ b/Assets/Scripts/Player/PlayerMovement.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+using UnityEngine.InputSystem;
+
+[RequireComponent(typeof(Rigidbody2D))]
+public class PlayerMovement : MonoBehaviour
+{
+    [Tooltip("Reference to the Move action from the Input System asset.")]
+    public InputActionReference moveAction;
+    [Tooltip("Movement speed in units per second.")]
+    public float moveSpeed = 5f;
+
+    private Rigidbody2D _rb;
+
+    private void Awake()
+    {
+        _rb = GetComponent<Rigidbody2D>();
+    }
+
+    private void OnEnable()
+    {
+        if (moveAction != null)
+            moveAction.action.Enable();
+    }
+
+    private void OnDisable()
+    {
+        if (moveAction != null)
+            moveAction.action.Disable();
+    }
+
+    private void FixedUpdate()
+    {
+        Vector2 input = Vector2.zero;
+        if (moveAction != null)
+            input = moveAction.action.ReadValue<Vector2>();
+
+        _rb.velocity = input * moveSpeed;
+    }
+}

--- a/Assets/Scripts/Player/PlayerMovement.cs.meta
+++ b/Assets/Scripts/Player/PlayerMovement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ff239c55fab45d8aa089f55182867e9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- add new `Scripts` directory with meta files
- implement `PlayerMovement` script using Unity Input System
- include meta files for Unity asset tracking

## Testing
- `python3 -m unittest discover`

------
https://chatgpt.com/codex/tasks/task_e_685312c18c4083208411657e705d7c61